### PR TITLE
Support deploying a single function

### DIFF
--- a/modules/filesystem.js
+++ b/modules/filesystem.js
@@ -8,7 +8,7 @@ function waitForFiles( path , callback ){
 
         readdir(path , function(err,filesInFolder){
 
-            if(filesInFolder.length == 4)
+            if(filesInFolder.length >= 4)
             {
                 clearInterval(interval)
                 callback()


### PR DESCRIPTION
When deploying a single function (via `serverless deploy function -f functionName`) there are 5 files added to the \_\_build\_\_.serverless folder:
- cloudformation-template-create-stack.json
- cloudformation-template-update-stack.json
- {functionName}.zip
- serverless-state.json
- {serviceName}.zip 

When deploying a service (via `serverless deploy`) there are 4 files added to the \_\_build\_\_.serverless folder:
- cloudformation-template-create-stack.json
- cloudformation-template-update-stack.json
- serverless-state.json
- {serviceName}.zip

This change enables support for both.