### PR TITLE
Handle more complex module structures

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const { resolvePath }                                    = require('./modules/pa
 const { asyncAwaitTranspile }                            = require('./modules/transpile.js')
 const { listFilesFoldersToCopy , listFilesToTranspile }  = require('./modules/readfolder.js')
 
+const pluginOutputPath = resolvePath(__dirname , '..','..', '__build__')
+
 
 class ServerlessPlugin 
 {
@@ -28,6 +30,7 @@ class ServerlessPlugin
     };
 
     this.hooks = {
+      'before:package:initialize': this.prepareServicePath.bind(this),
       'before:package:createDeploymentArtifacts' : this.transpileProject.bind(this),
       'after:package:createDeploymentArtifacts' : this.cleanup.bind(this),
       'before:deploy:function:packageFunction': this.transpileProject.bind(this),
@@ -36,13 +39,14 @@ class ServerlessPlugin
   }
 
 
-
+  prepareServicePath() {
+    this.serverless.config.servicePath = pluginOutputPath 
+  }
 
 
   transpileProject() 
   {
 
-    var pluginOutputPath   = resolvePath(__dirname , '..','..', '__build__')
     var projectPath        = resolvePath(__dirname , '..' , '..')
     
     var filesToTranspile     = []
@@ -90,8 +94,6 @@ class ServerlessPlugin
 
         writeFile( transpiledFilePath , transpiledCode)  
     }
-
-    this.serverless.config.servicePath = pluginOutputPath 
 
   }
 

--- a/modules/readfolder.js
+++ b/modules/readfolder.js
@@ -2,7 +2,7 @@ var glob = require('glob')
 
 function listFilesToTranspile(path , exclude){
 
-    var ignoredFiles = ["node_modules/**", "__build__/**" ]
+    var ignoredFiles = ["**/node_modules/**", "__build__/**" ]
     ignoredFiles     = ignoredFiles.concat(exclude)
 
     var files = glob.sync('**/*.js', { root : path , ignore : ignoredFiles })
@@ -24,9 +24,9 @@ function listFilesFoldersToCopy(path , exclude ){
 
     
 
-    var files                 = glob.sync('*.*',{ root : path , ignore : ignoredFiles   })
-    var filesWithNoName       = glob.sync('*'  ,{ root : path , ignore : ignoredFiles   })
-    var filesWithDotExtension = glob.sync('.*'  ,{ root : path , ignore : ignoredFiles   })
+    var files                 = glob.sync('*.*',{ root : path , ignore : ignoredFiles, nodir: true   })
+    var filesWithNoName       = glob.sync('*'  ,{ root : path , ignore : ignoredFiles, nodir: true   })
+    var filesWithDotExtension = glob.sync('.*'  ,{ root : path , ignore : ignoredFiles, nodir: true   })
     
     var folders = glob.sync('*/', { root : path , ignore : ignoredFolders })
 


### PR DESCRIPTION
I got a few issues when trying out the plugin in a more complex structure where I had a serverless project with individual handler directories with their own npm modules. The problem was that it did not exclude all `node_modules` directories from the files to transpile, and it also include stuff twice due to entries matching multiple listings in in `listFilesFoldersToCopy`. 